### PR TITLE
Improve touchscreen devices support

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -7,6 +7,7 @@ body {
 }
 .board {
   cursor: move;
+  touch-action: none;
   position: absolute;
   top: 0;
   right: 0;


### PR DESCRIPTION
Hey! Since you mention that you welcome contributions here's my grain of sand.

Changes:
- Disable touch actions on canvas so PointerEvents work properly on touchscreens.

At the moment on touchscreens a [pointercancel](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/pointercancel_evnt) event is triggered right after pointerdown making panning & zooming with pointerevents almost impossible. This disables that behaviour.

Disclaimer: I tested this on chrome's responsive view, not on an actual mobile device.

Cheers.